### PR TITLE
refactor(swc): simplify pattern matching usage

### DIFF
--- a/swc/src/lib.rs
+++ b/swc/src/lib.rs
@@ -105,7 +105,7 @@ impl Fold for RawMacro {
 
         match &expr {
             Expr::Call(CallExpr { args, callee: Callee::Expr(cex), ..}) => 
-                // in the feature stable of rust boxed, wee can use 
+                // in the feature stable of rust boxed, we can use 
                 // match someBox { box Expr::Ident(i) => ... }
                 match &**cex {
                     Expr::Ident(i) => 


### PR DESCRIPTION
Hello @pveyes 

I'm just want to say "thank you very much" for make this useful tools and I want to give some contributions

### Changes

* in fold_expr for replace call expression to be string literal
* in fold_module_items for remove raw.macro import