### PR TITLE
Upgrade packages

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx pretty-quick

--- a/package.json
+++ b/package.json
@@ -17,10 +17,9 @@
   },
   "license": "MIT",
   "files": [
-    "dist/*",
+    "dist/",
     "raw.macro.d.ts",
-    "swc/target/wasm32-wasi/release/swc_plugin_raw_macro.wasm",
-    "src/*"
+    "swc/target/wasm32-wasi/release/swc_plugin_raw_macro.wasm"
   ],
   "keywords": [
     "webpack",
@@ -40,7 +39,6 @@
     "build": "microbundle src/*.js",
     "format": "prettier --write",
     "ci": "npm run test -- --ci && npm run build",
-    "preinstall": "npm run build",
     "prepublishOnly": "npm run build && npm run swc",
     "swc": "npm run swc:build && npm run swc:jest",
     "swc:build": "cargo build --manifest-path ./swc/Cargo.toml --release --target=wasm32-wasi",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "license": "MIT",
   "files": [
-    "./dist",
+    "dist/*",
     "raw.macro.d.ts",
     "swc/target/wasm32-wasi/release/swc_plugin_raw_macro.wasm",
-    "./src"
+    "src/*"
   ],
   "keywords": [
     "webpack",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "raw.macro",
   "description": "Read file contents at build time, similar to webpack raw-loader",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "engines": {
     "node": ">=14.0.0"
   },
+  "type": "module",
   "types": "raw.macro.d.ts",
   "main": "./dist/raw.macro.js",
   "exports": {
@@ -35,16 +36,17 @@
   },
   "scripts": {
     "test": "jest --coverage",
-    "build": "microbundle",
+    "build": "microbundle src/*.js",
     "format": "prettier --write",
     "ci": "npm run test -- --ci && npm run build",
     "prepublishOnly": "npm run build && npm run swc",
     "swc": "npm run swc:build && npm run swc:jest",
     "swc:build": "cargo build --manifest-path ./swc/Cargo.toml --release --target=wasm32-wasi",
-    "swc:jest": "jest --config swc/test/jest.config.js --no-cache"
+    "swc:jest": "jest --config swc/test/jest.config.js --no-cache",
+    "prepare": "husky"
   },
   "peerDependencies": {
-    "babel-plugin-macros": "^2.8.0"
+    "babel-plugin-macros": "^3.1.0"
   },
   "peerDependenciesMeta": {
     "babel-plugin-macros": {
@@ -52,23 +54,18 @@
     }
   },
   "devDependencies": {
-    "@babel/core": "^7.10.5",
-    "@swc/core": "^1.3.11",
-    "@swc/jest": "^0.2.23",
-    "babel-plugin-tester": "^9.2.0",
-    "husky": "^4.2.5",
-    "jest": "^26.1.0",
-    "microbundle": "^0.12.3",
-    "prettier": "^2.0.5",
-    "pretty-quick": "^2.0.1",
-    "rollup": "^2.22.1"
+    "@babel/core": "^7.24.5",
+    "@swc/core": "^1.5.7",
+    "@swc/jest": "^0.2.36",
+    "babel-plugin-tester": "^11.0.4",
+    "husky": "^9.0.11",
+    "jest": "^29.7.0",
+    "microbundle": "^0.15.1",
+    "prettier": "^3.2.5",
+    "pretty-quick": "^4.0.0",
+    "rollup": "^4.18.0"
   },
   "jest": {
     "testRegex": "__tests__/.*.test.js$"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "pretty-quick"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build": "microbundle src/*.js",
     "format": "prettier --write",
     "ci": "npm run test -- --ci && npm run build",
+	"preinstall": "npm run build",
     "prepublishOnly": "npm run build && npm run swc",
     "swc": "npm run swc:build && npm run swc:jest",
     "swc:build": "cargo build --manifest-path ./swc/Cargo.toml --release --target=wasm32-wasi",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "files": [
     "dist/",
     "raw.macro.d.ts",
-    "swc/target/wasm32-wasi/release/swc_plugin_raw_macro.wasm"
+    "swc/target/wasm32-wasi/release/swc_plugin_raw_macro.wasm",
+	"src/"
   ],
   "keywords": [
     "webpack",
@@ -39,7 +40,7 @@
     "build": "microbundle src/*.js",
     "format": "prettier --write",
     "ci": "npm run test -- --ci && npm run build",
-	"preinstall": "npm run build",
+    "preinstall": "npm run build",
     "prepublishOnly": "npm run build && npm run swc",
     "swc": "npm run swc:build && npm run swc:jest",
     "swc:build": "cargo build --manifest-path ./swc/Cargo.toml --release --target=wasm32-wasi",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "license": "MIT",
   "files": [
-    "dist/",
+    "./dist",
     "raw.macro.d.ts",
     "swc/target/wasm32-wasi/release/swc_plugin_raw_macro.wasm",
-	"src/"
+    "./src"
   ],
   "keywords": [
     "webpack",


### PR DESCRIPTION
This upgrades all of the dependencies and the peer dependency on babel-plugin-macros. All builds well and have tested the /dist folder with my own code with no errors. I don't use Rust, so although I have check that builds, I haven't carried out any testing on that side of things.

Husky does pre-commit differently now, hence the new file for that.